### PR TITLE
Incremental search and history browse change.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -310,6 +310,14 @@ impl Buffer {
         }
     }
 
+    /// Check if the buffer contains pattern.
+    /// Used to implement history search.
+    pub fn contains(&self, pattern: &Buffer) -> bool {
+        let stested: String = self.to_string();
+        let search_term = pattern.to_string();
+        stested.contains(&search_term)
+    }
+
     /// Return true if the buffer is empty.
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -489,6 +489,33 @@ mod tests {
     }
 
     #[test]
+    fn test_contains() {
+        let mut buf = Buffer::new();
+        buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+        let mut buf2 = Buffer::new();
+        buf2.insert(0, &['a', 'b', 'c']);
+        assert_eq!(buf.contains(&buf2), true);
+        let mut buf2 = Buffer::new();
+        buf2.insert(0, &['c', 'd', 'e']);
+        assert_eq!(buf.contains(&buf2), true);
+        let mut buf2 = Buffer::new();
+        buf2.insert(0, &['e', 'f', 'g']);
+        assert_eq!(buf.contains(&buf2), true);
+    }
+
+    #[test]
+    fn test_does_not_contain() {
+        let mut buf = Buffer::new();
+        buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+        let mut buf2 = Buffer::new();
+        buf2.insert(0, &['x', 'b', 'c']);
+        assert_eq!(buf.contains(&buf2), false);
+        let mut buf2 = Buffer::new();
+        buf2.insert(0, &['a', 'b', 'd']);
+        assert_eq!(buf.contains(&buf2), false);
+    }
+
+    #[test]
     fn test_print_rest() {
         let mut buf = Buffer::new();
         buf.insert(0, &['a', 'b', 'c', 'd', 'e', 'f', 'g']);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -223,6 +223,12 @@ impl Buffer {
         self.insert(start, &other.data[start..])
     }
 
+    pub fn copy_buffer(&mut self, other: &Buffer) {
+        let data_len = self.data.len();
+        self.remove(0, data_len);
+        self.insert(0, &other.data[0..])
+    }
+
     pub fn range(&self, start: usize, end: usize) -> String {
         self.data[start..end].iter().cloned().collect()
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -108,22 +108,39 @@ impl History {
         });
     }
 
-    /// Go through the history and try to find a buffer which starts the same as the new buffer
-    /// given to this function as argument.
-    pub fn get_newest_match<'a, 'b>(
-        &'a self,
-        curr_position: Option<usize>,
-        new_buff: &'b Buffer,
-    ) -> Option<&'a Buffer> {
-        let pos = curr_position.unwrap_or_else(|| self.buffers.len());
-        for iter in (0..pos).rev() {
-            if let Some(tested) = self.buffers.get(iter) {
-                if tested.starts_with(new_buff) {
-                    return self.buffers.get(iter);
+    fn get_match<I>(&self, vals: I, search_term: &Buffer) -> Option<usize>
+        where I: Iterator<Item = usize>
+    {
+        for i in vals {
+            if let Some(tested) = self.buffers.get(i) {
+                if tested.starts_with(search_term) {
+                    return Some(i);
                 }
             }
         }
         None
+    }
+
+    /// Go through the history and try to find an index (newest to oldest) which starts the same
+    /// as the new buffer given to this function as argument.  Starts at curr_position.  Does no wrap.
+    pub fn get_newest_match(&self, curr_position: Option<usize>, new_buff: &Buffer, ) -> Option<usize> {
+        let pos = curr_position.unwrap_or_else(|| self.buffers.len());
+        if pos > 0 {
+            self.get_match((0..pos).rev(), new_buff)
+        } else {
+            None
+        }
+    }
+
+    /// Go through the history and try to find an index (oldest to newest) which starts the same
+    /// as the new buffer given to this function as argument.  Starts at curr_position.  Does not wrap.
+    pub fn get_oldest_match(&self, curr_position: Option<usize>, new_buff: &Buffer, ) -> Option<usize> {
+        let pos = curr_position.unwrap_or_else(|| 0);
+        if pos < self.len() {
+            self.get_match(pos..self.len(), new_buff)
+        } else {
+            None
+        }
     }
 
     fn search_index<I>(&self, vals: I, search_term: &Buffer) -> Option<usize>

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -38,7 +38,10 @@ pub trait KeyMap<'a, W: Write, T>: From<T> {
                 self.editor_mut().accept_autosuggestion()?;
             }
             Key::Ctrl('r') => {
-                self.editor_mut().reverse_search();
+                self.editor_mut().search(false)?;
+            }
+            Key::Ctrl('s') => {
+                self.editor_mut().search(true)?;
             }
             Key::Right if self.editor().is_currently_showing_autosuggestion() &&
                           self.editor().cursor_is_at_end_of_line() => {

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -37,10 +37,10 @@ pub trait KeyMap<'a, W: Write, T>: From<T> {
             Key::Ctrl('f') if self.editor().is_currently_showing_autosuggestion() => {
                 self.editor_mut().accept_autosuggestion()?;
             }
-            Key::Ctrl('s') => {
+            Key::Ctrl('k') => {
                 self.editor_mut().search(false)?;
             }
-            Key::Ctrl('j') => {
+            Key::Ctrl('s') => {
                 self.editor_mut().search(true)?;
             }
             Key::Right if self.editor().is_currently_showing_autosuggestion() &&

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -37,6 +37,9 @@ pub trait KeyMap<'a, W: Write, T>: From<T> {
             Key::Ctrl('f') if self.editor().is_currently_showing_autosuggestion() => {
                 self.editor_mut().accept_autosuggestion()?;
             }
+            Key::Ctrl('r') => {
+                self.editor_mut().reverse_search();
+            }
             Key::Right if self.editor().is_currently_showing_autosuggestion() &&
                           self.editor().cursor_is_at_end_of_line() => {
                 self.editor_mut().accept_autosuggestion()?;

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -37,10 +37,10 @@ pub trait KeyMap<'a, W: Write, T>: From<T> {
             Key::Ctrl('f') if self.editor().is_currently_showing_autosuggestion() => {
                 self.editor_mut().accept_autosuggestion()?;
             }
-            Key::Ctrl('r') => {
+            Key::Ctrl('s') => {
                 self.editor_mut().search(false)?;
             }
-            Key::Ctrl('s') => {
+            Key::Ctrl('j') => {
                 self.editor_mut().search(true)?;
             }
             Key::Right if self.editor().is_currently_showing_autosuggestion() &&

--- a/src/keymap/vi.rs
+++ b/src/keymap/vi.rs
@@ -1202,11 +1202,12 @@ mod tests {
         ]);
         assert_eq!(map.ed.cursor(), 0);
     }
+
     #[test]
     fn vi_normal_history_cursor_eol() {
         let mut context = Context::new();
-        context.history.push("history".into()).unwrap();
-        context.history.push("history".into()).unwrap();
+        context.history.push("data hostory".into()).unwrap();
+        context.history.push("data history".into()).unwrap();
         let out = Vec::new();
         let ed = Editor::new(out, "prompt".to_owned(), None, &mut context).unwrap();
         let mut map = Vi::new(ed);
@@ -1214,11 +1215,69 @@ mod tests {
         assert_eq!(map.ed.cursor(), 4);
 
         simulate_keys!(map, [Up]);
-        assert_eq!(map.ed.cursor(), 7);
+        assert_eq!(map.ed.cursor(), 12);
 
         // in normal mode, make sure we don't end up past the last char
         simulate_keys!(map, [Ctrl('['), Up]);
-        assert_eq!(map.ed.cursor(), 6);
+        assert_eq!(map.ed.cursor(), 11);
+    }
+
+    #[test]
+    fn vi_normal_history() {
+        let mut context = Context::new();
+        context.history.push("data second".into()).unwrap();
+        context.history.push("skip1".into()).unwrap();
+        context.history.push("data one".into()).unwrap();
+        context.history.push("skip2".into()).unwrap();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), None, &mut context).unwrap();
+        let mut map = Vi::new(ed);
+        map.ed.insert_str_after_cursor("data").unwrap();
+        assert_eq!(map.ed.cursor(), 4);
+
+        simulate_keys!(map, [Up]);
+        assert_eq!(map.ed.cursor(), 8);
+
+        // in normal mode, make sure we don't end up past the last char
+        simulate_keys!(map, [Ctrl('['), Char('k')]);
+        assert_eq!(map.ed.cursor(), 10);
+    }
+
+    #[test]
+    fn vi_search_history() {
+        // Test incremental search as well as vi binding in search mode.
+        let mut context = Context::new();
+        context.history.push("data pat second".into()).unwrap();
+        context.history.push("skip1".into()).unwrap();
+        context.history.push("data pat one".into()).unwrap();
+        context.history.push("skip2".into()).unwrap();
+        let out = Vec::new();
+        let ed = Editor::new(out, "prompt".to_owned(), None, &mut context).unwrap();
+        let mut map = Vi::new(ed);
+        map.ed.insert_str_after_cursor("pat").unwrap();
+        assert_eq!(map.ed.cursor(), 3);
+        simulate_keys!(map, [Ctrl('k'), Right]);
+        assert_eq!(map.ed.cursor(), 12);
+
+        //simulate_keys!(map, [Ctrl('['), Char('u'), Char('i')]);
+        map.ed.delete_all_before_cursor().unwrap();
+        assert_eq!(map.ed.cursor(), 0);
+        //map.ed.insert_str_after_cursor("pat").unwrap();
+        //assert_eq!(map.ed.cursor(), 3);
+        simulate_keys!(map, [Ctrl('k'), Char('p'), Char('a'), Char('t'), Ctrl('['), Char('k'), Ctrl('f')]);
+        assert_eq!(map.ed.cursor(), 14);
+
+        simulate_keys!(map, [Ctrl('['), Char('u'), Char('i')]);
+        assert_eq!(map.ed.cursor(), 0);
+        simulate_keys!(map, [Ctrl('s'), Char('p'), Char('a'), Char('t'), Ctrl('f')]);
+        assert_eq!(map.ed.cursor(), 15);
+
+        map.ed.delete_all_before_cursor().unwrap();
+        assert_eq!(map.ed.cursor(), 0);
+        map.ed.insert_str_after_cursor("pat").unwrap();
+        assert_eq!(map.ed.cursor(), 3);
+        simulate_keys!(map, [Ctrl('s'), Ctrl('['), Char('j'), Right]);
+        assert_eq!(map.ed.cursor(), 11);
     }
 
     #[test]
@@ -3347,7 +3406,7 @@ mod tests {
     /// test undo in groups
     fn undo_insert_with_history() {
         let mut context = Context::new();
-        context.history.push(Buffer::from("")).unwrap();
+        context.history.push(Buffer::from("insert something")).unwrap();
         let out = Vec::new();
         let ed = Editor::new(out, "prompt".to_owned(), None, &mut context).unwrap();
         let mut map = Vi::new(ed);

--- a/src/test.rs
+++ b/src/test.rs
@@ -126,7 +126,7 @@ fn test_reading_from_file() {
         f.write_all(TEXT.as_bytes()).unwrap();
     }
     let mut h = History::new();
-    h.set_file_name_and_load_history(tmp_file);
+    h.set_file_name_and_load_history(tmp_file).unwrap();
     assert_eq!(String::from(h.buffers[0].clone()), "a".to_string());
     assert_eq!(String::from(h.buffers[1].clone()), "b".to_string());
     assert_eq!(String::from(h.buffers[2].clone()), "c".to_string());


### PR DESCRIPTION
Adds incremental search (bound to ctrl-k for reverse and ctrl-s for forward).  Reverse search searches most recent to oldest.  Similar to read_line ctrl-r (ctrl-r was taken by vi binding), main differences are that up/down keys move in search and searches wrap.

Also changes history browsing.  If something has been typed then up/down will only browse through history that starts with those characters.  Wraps on up but not down (puts you back to your starting point).

Running rustfmt seems to change a lot of code other then mine so leaving out for now for clarity but obviously will run if requested.  All tests should pass.
